### PR TITLE
feat: shell 工具描述随默认终端设置动态重渲染

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,8 +13,10 @@
 // handles with the generic ctx.jobs registry, mirroring the shipped
 // dsh-tool-bash / dsh-tool-pwsh story call-for-call. It deliberately
 // does NOT consume the ctx.shell capability seam: the platform's own
-// sandboxed PowerShell executor keeps serving the pwsh tool, and this tool
-// is an additional, user-selected terminal that runs outside the sandbox.
+// sandboxed PowerShell executor keeps serving the pwsh tool. This tool is
+// an additional, user-selected terminal that still honors the DSH sandbox:
+// confined modes wrap the spawn argv through ctx.sandbox (fail-closed),
+// while danger-full-access and WSL run unconfined.
 
 import { defineTool, TOOL_ABORTED } from "@deepseek-ai/dsh-tools";
 import { createTerminalRegistry, terminalTool } from "./terminal.js";
@@ -347,7 +349,7 @@ function toolDescription(backgroundEnabled, shell = DEFAULT_SHELL) {
   const base = [
     `The user's chosen default terminal (Settings -> General -> Default terminal) is ${active}; commands run there.`,
     lead,
-    "Each call spawns a fresh shell: no state (cwd, variables, aliases) persists between calls - pass workdir instead of using cd. Non-zero exits are reported as [exit code: N] markers; investigate failures before moving on. Long output is truncated to its tail; the full output is saved to a file whose path is reported when available. Commands run outside the DSH sandbox with the same privileges as the dsh process itself."
+    "Each call spawns a fresh shell: no state (cwd, variables, aliases) persists between calls - pass workdir instead of using cd. Non-zero exits are reported as [exit code: N] markers; investigate failures before moving on. Long output is truncated to its tail; the full output is saved to a file whose path is reported when available. Commands run under the DSH sandbox: confined modes (read-only / workspace-write) are enforced through ctx.sandbox and deny fail-closed; danger-full-access and the WSL backend run unconfined."
   ].join(" ");
   if (!backgroundEnabled) return base;
   return base + " Set run_in_background: true for long-running commands: the call returns a job id immediately; read its output with job_output and stop it with job_kill. No timeout applies to background runs.";

--- a/lib/index.js
+++ b/lib/index.js
@@ -326,12 +326,27 @@ function renderProcessRead(read) {
 
 // ---- tool description / validation --------------------------------------------
 
-function toolDescription(backgroundEnabled) {
+/** Model-facing lead sentence for each backend. The user's default terminal is
+ * stated up front so the model never has to guess which syntax applies. */
+const SHELL_DESCRIPTIONS = {
+  powershell: "Execute a PowerShell command (pwsh -NoLogo -NoProfile -NonInteractive -Command <command>) and return its stdout/stderr. PowerShell syntax; native Windows paths (C:\\...); environment variables via $env:NAME.",
+  gitbash: "Execute a bash command (Git for Windows bash -lc <command>) and return its stdout/stderr. POSIX syntax; paths like /d/WorkSpace; PATH includes /usr/bin and /mingw64/bin so git, npm, ssh etc. work; environment variables via $NAME.",
+  wsl: "Execute a Linux bash command (wsl [-d <distro>] -e bash -lc <command>) and return its stdout/stderr. Linux syntax; Windows files under /mnt/d/...; environment variables via $NAME."
+};
+
+/**
+ * Render the model-facing tool description for one backend. The backend is
+ * whatever the user chose in Settings -> General -> Default terminal; the
+ * description names it explicitly so the model writes the right syntax.
+ * @param backgroundEnabled - advertise `run_in_background` controls.
+ * @param shell - active backend; unknown values fall back to the default.
+ */
+function toolDescription(backgroundEnabled, shell = DEFAULT_SHELL) {
+  const active = SHELL_DESCRIPTIONS[shell] !== undefined ? shell : DEFAULT_SHELL;
+  const lead = SHELL_DESCRIPTIONS[active];
   const base = [
-    "Execute a command in a Windows terminal. The terminal backend (powershell / gitbash / wsl) is chosen by the user in the Web UI settings (default terminal) — never guess or override it; use whatever the user configured. Prefer this tool over pwsh for terminal commands. Backends:",
-    "- powershell: runs pwsh -NoLogo -NoProfile -NonInteractive -Command <command>. PowerShell syntax; native Windows paths (C:\\...); environment variables via $env:NAME.",
-    "- gitbash: runs Git for Windows' bash -lc <command>. POSIX syntax; paths like /d/WorkSpace; PATH includes /usr/bin and /mingw64/bin so git, npm, ssh etc. work; environment variables via $NAME.",
-    "- wsl: runs inside the default WSL Linux distribution via wsl -e bash -lc <command>; pass distro (e.g. Ubuntu) to pick another. Linux syntax; Windows files under /mnt/d/...; environment variables via $NAME.",
+    `The user's chosen default terminal (Settings -> General -> Default terminal) is ${active}; commands run there.`,
+    lead,
     "Each call spawns a fresh shell: no state (cwd, variables, aliases) persists between calls - pass workdir instead of using cd. Non-zero exits are reported as [exit code: N] markers; investigate failures before moving on. Long output is truncated to its tail; the full output is saved to a file whose path is reported when available. Commands run outside the DSH sandbox with the same privileges as the dsh process itself."
   ].join(" ");
   if (!backgroundEnabled) return base;
@@ -445,9 +460,23 @@ export function apply(ctx, config = {}) {
   const terminalRegistry = createTerminalRegistry(ctx);
   ctx.tools.register(terminalTool(ctx, terminalRegistry, paths, () => settingsScope.get().defaultShell));
 
+  // The model-facing description must track the user's chosen default
+  // terminal: a static description listing every backend leaves the model
+  // guessing which syntax applies. Re-render it on every prompt assembly —
+  // settings are hot-reloaded, so a change shows up on the next request
+  // without a restart.
+  ctx.on("system-prompt/assemble", async (_assembly, _context, next) => {
+    const assembled = await next();
+    const description = toolDescription(backgroundEnabled, settingsScope.get().defaultShell);
+    const tools = Array.isArray(assembled.tools)
+      ? assembled.tools.map((tool) => (tool.name === toolName ? { ...tool, description } : tool))
+      : assembled.tools;
+    return { ...assembled, tools };
+  });
+
   ctx.tools.register(defineTool({
     name: toolName,
-    description: toolDescription(backgroundEnabled),
+    description: toolDescription(backgroundEnabled, settingsScope.get().defaultShell),
     parameters: {
       command: {
         type: "string",
@@ -648,6 +677,8 @@ export const internals = {
   buildEnv,
   buildArgv,
   validateArgs,
+  toolDescription,
+  SHELL_DESCRIPTIONS,
   DEFAULT_TIMEOUT_MS,
   MAX_TIMEOUT_MS,
   DEFAULT_MAX_OUTPUT_BYTES

--- a/test/apply.mjs
+++ b/test/apply.mjs
@@ -5,10 +5,12 @@ import assert from "node:assert";
 let registered = null;
 let userDefaultShell = "powershell"; // what the user picked in the Web UI
 let sandboxMode = "danger-full-access"; // per-call sandbox policy mode
+let assembleHandler = null; // captured system-prompt/assemble waterfall listener
 const ctx = {
   logger: { info: () => {} },
   systemPrompt: { section: (s) => { assert.ok(s.name === "tool:bash-terminal"); } },
   tools: { register: (tool) => { registered = tool; } },
+  on: (event, handler) => { if (event === "system-prompt/assemble") assembleHandler = handler; },
   shellEnv: { collect: () => ({ DSH_WEB_URL: "http://127.0.0.1:3080" }) },
   settings: {
     register: (ns, schema, options) => {
@@ -161,5 +163,33 @@ await assert.rejects(() => registered.execute({ command: "", description: "t" },
 // settings schema rejects an out-of-enum user value
 userDefaultShell = "fish";
 await assert.rejects(() => registered.execute({ command: "x", description: "t" }, exec));
+
+// ---- system-prompt/assemble: description re-renders with the user's shell ----
+
+assert.ok(assembleHandler, "assemble waterfall listener registered");
+const makeAssembly = () => ({
+  tools: [
+    { name: "shell", description: "stale-description" },
+    { name: "read", description: "read a file" }
+  ],
+  sections: [],
+  contexts: []
+});
+
+// gitbash user setting -> bash-flavored description for the shell tool only.
+userDefaultShell = "gitbash";
+const gitAssembly = await assembleHandler(makeAssembly(), {}, async () => makeAssembly());
+assert.ok(gitAssembly.tools[0].description.includes("bash -lc"), "gitbash description applied");
+assert.ok(gitAssembly.tools[0].description.includes("is gitbash"), "gitbash backend named");
+assert.strictEqual(gitAssembly.tools[1].description, "read a file", "other tools untouched");
+
+// Hot-reload: switching the setting re-renders on the next assembly.
+userDefaultShell = "powershell";
+const psAssembly = await assembleHandler(makeAssembly(), {}, async () => makeAssembly());
+assert.ok(psAssembly.tools[0].description.includes("pwsh -NoLogo"), "powershell description applied after setting change");
+assert.ok(!psAssembly.tools[0].description.includes("bash -lc"), "stale gitbash description gone");
+
+// Registration-time description already matches the initial setting.
+assert.ok(registered.description.includes("is powershell"), "registration-time description matches initial default");
 
 console.log("APPLY/EXECUTE MOCK TESTS PASSED");

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -1,6 +1,6 @@
 
 import { buildArgv, buildEnv, candidateGitBashPaths, candidatePwshPaths, internals } from "../lib/index.js";
-const { renderResult, resolveAllPaths, validateArgs } = internals;
+const { renderResult, resolveAllPaths, validateArgs, toolDescription, SHELL_DESCRIPTIONS } = internals;
 import assert from "node:assert";
 
 const paths = { pwsh: "C:\\pwsh.exe", gitbash: "C:\\Git\\bin\\bash.exe", wsl: "C:\\Windows\\System32\\wsl.exe" };
@@ -37,5 +37,39 @@ assert.throws(() => validateArgs({ command: "  ", description: "x" }));
 // shell is user-settings controlled: a stale shell arg must be tolerated
 validateArgs({ command: "ls", description: "x", shell: "fish" });
 assert.throws(() => validateArgs({ command: "ls", description: "x", timeoutMs: -5 }));
+
+// ---- backend-aware tool description -----------------------------------------
+
+// Every backend is covered by its own lead sentence.
+assert.deepStrictEqual(Object.keys(SHELL_DESCRIPTIONS).sort(), ["gitbash", "powershell", "wsl"]);
+
+// gitbash -> bash-flavored description; the active backend is named up front.
+const gitDesc = toolDescription(true, "gitbash");
+assert.ok(gitDesc.includes("bash -lc"), "gitbash lead mentions bash -lc: " + gitDesc);
+assert.ok(gitDesc.includes("POSIX syntax"), "gitbash lead mentions POSIX");
+assert.ok(gitDesc.includes("The user's chosen default terminal (Settings -> General -> Default terminal) is gitbash"), "gitbash names the active backend");
+
+// powershell -> PowerShell-flavored description.
+const psDesc = toolDescription(true, "powershell");
+assert.ok(psDesc.includes("pwsh -NoLogo -NoProfile -NonInteractive -Command"), "powershell lead mentions pwsh argv");
+assert.ok(psDesc.includes("PowerShell syntax"), "powershell lead mentions PowerShell");
+assert.ok(psDesc.includes("is powershell"), "powershell names the active backend");
+
+// wsl -> Linux-bash-flavored description.
+const wslDesc = toolDescription(true, "wsl");
+assert.ok(wslDesc.includes("wsl [-d <distro>] -e bash -lc"), "wsl lead mentions wsl argv");
+assert.ok(wslDesc.includes("/mnt/"), "wsl lead mentions /mnt/ paths");
+assert.ok(wslDesc.includes("is wsl"), "wsl names the active backend");
+
+// Shared tail: fresh shell, exit codes, background controls.
+for (const desc of [gitDesc, psDesc, wslDesc]) {
+  assert.ok(desc.includes("spawns a fresh shell"), "shared fresh-shell tail");
+  assert.ok(desc.includes("[exit code: N]"), "shared exit-code tail");
+  assert.ok(desc.includes("run_in_background: true"), "background advertised when enabled");
+}
+assert.ok(!toolDescription(false, "gitbash").includes("run_in_background"), "background hidden when disabled");
+
+// Unknown backend falls back to the default lead without throwing.
+assert.ok(toolDescription(true, "fish").includes("is powershell"), "unknown backend falls back to default");
 
 console.log("ALL UNIT TESTS PASSED");

--- a/test/unit.mjs
+++ b/test/unit.mjs
@@ -66,6 +66,8 @@ for (const desc of [gitDesc, psDesc, wslDesc]) {
   assert.ok(desc.includes("spawns a fresh shell"), "shared fresh-shell tail");
   assert.ok(desc.includes("[exit code: N]"), "shared exit-code tail");
   assert.ok(desc.includes("run_in_background: true"), "background advertised when enabled");
+  assert.ok(desc.includes("under the DSH sandbox"), "sandbox honored in description");
+  assert.ok(!desc.includes("outside the DSH sandbox"), "no stale outside-sandbox claim");
 }
 assert.ok(!toolDescription(false, "gitbash").includes("run_in_background"), "background hidden when disabled");
 


### PR DESCRIPTION
### 问题

模型看到的 `shell` 工具描述是静态的，把三种后端全部罗列出来（"终端后端（powershell / gitbash / wsl）由用户在 Web UI 设置中选择……永远不要猜测"）。模型因此无法判断自己的命令实际运行在 PowerShell、Git Bash 还是 WSL 里——描述明确禁止它猜测，但它必须写对的语法恰恰完全取决于用户选中的后端。

### 修复

按**当前生效的后端**渲染工具描述：

- `toolDescription(backgroundEnabled, shell)` 接收后端参数，生成对应的主体描述（pwsh 命令行 / Git for Windows `bash -lc` / `wsl -e bash -lc`，以及各自匹配的语法、路径、环境变量约定），公共尾段（全新 shell / 退出码 / 后台任务）保持不变。
- 首句直接点名用户的选择："The user's chosen default terminal (Settings -> General -> Default terminal) is `<shell>`"。
- 新增 `system-prompt/assemble` 瀑布监听：每次提示词装配时按 `settingsScope.get().defaultShell` 重新渲染描述。设置是热加载的，所以在 Web UI 里切换"默认终端"后，**下一次请求即生效，无需重启**；注册时的初始描述也已与当前设置一致。
- 未知后端值回退到默认描述（设置 schema 本就约束了枚举，这里只是防御）。

### 沙箱描述修正

顺带修正描述与实现不符的历史文案：工具描述和头部注释原先声称命令"在 DSH 沙箱外运行"，但 `execute()` 一直通过 `ctx.sandbox.confine` 对 spawn argv 做 fail-closed 沙箱包装（`danger-full-access` 与 WSL 后端除外，后者自带 VM 隔离）。现改为与实现一致的表述，并加了对应断言防止回退。

### 测试

- `test/unit.mjs`：`SHELL_DESCRIPTIONS` 覆盖三种后端；逐一断言各后端的命令行/语法特征与"点名当前后端"的首句；共享尾段、后台开关、沙箱表述；未知后端回退。
- `test/apply.mjs`：mock `ctx.on` 捕获 assemble 监听；断言用户设置从 gitbash 切到 powershell 时（热更新）shell 工具描述随之重渲染、其他工具不受影响、注册时描述与初始设置一致。
- `npm test` 本地全部通过（unit + apply/execute + client）。

### 备注

上游没有覆盖此需求的 issue 或 PR；需求来自实际使用：默认终端设为 Git Bash 时，两阶段锚定预设首轮只交给 agent 这个工具和 `read`，agent 必须仅凭工具描述就知道自己在写 bash。
